### PR TITLE
Improvement: Floating URL bar, behaves like the native Firefox URL bar

### DIFF
--- a/floating-urlbar/userChrome.css
+++ b/floating-urlbar/userChrome.css
@@ -1,4 +1,4 @@
-#urlbar:is([breakout][breakout-extend], [breakout][usertyping][focused]) {
+#urlbar:is([breakout][breakout-extend], [focused]) {
     #urlbar-input {
         font-size: 16px !important;
     }


### PR DESCRIPTION
- By removing those two pseudo-classes from the matching condition, including the focused pseudo-class, the URL bar behaves same as the Firefox default URL bar. As it will now activate whenever the URL bar is focused in the window.
- This will allow the URL bar, open on creating a new tab by default.
- It will now popup anytime the URL bar is focused, instead of waiting for the user to type something in the URL bar.
- **NOTE**: But one important caveat is that, on pressing escape the URL bar popup will no longer close. But this is also the behavior of the default Firefox URL bar.