### PR TITLE
Add 0.2s Transition of URL Bar

### DIFF
--- a/floating-urlbar/userChrome.css
+++ b/floating-urlbar/userChrome.css
@@ -14,6 +14,8 @@
     right: 18vw !important;
     width: 64vw !important;
 
+    transition: all 0.2s ease-in-out !important;
+
     &:after {
         content: "";
         position: fixed;


### PR DESCRIPTION
# Smoothed out transition of URL bar

added `transition: all 0.4s ease-in-out !important;` to make the transition from a fixed bar to a floating one smooth